### PR TITLE
implement `must_let!` to bind values using syntax mimicking `let` bindings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,3 +128,107 @@ macro_rules! get {
         }
     }};
 }
+
+/// The `must_let!` macro also provides a non-total way to access enum fields.
+/// Instead of producing a value it binds variables using a syntax that
+/// resembles native Rust let bindings with pattern matching. The difference is
+/// that the compiler will allow a pattern in the `must_let!` macro that might
+/// not match.
+///
+/// ```
+/// use unsafe_get::must_let;
+///
+/// #[derive(Debug)]
+/// enum ExampleEnum {
+///   Foo { field: i32 },
+///   Bar { other_field: String },
+/// }
+///
+/// let value = ExampleEnum::Foo { field: 42 };
+/// must_let!(ExampleEnum::Foo { field } = value);
+/// assert_eq!(field, 42);
+/// ```
+///
+/// If the given pattern does not match, `must_let!` will panic.
+///
+/// ```should_panic
+/// use unsafe_get::must_let;
+///
+/// #[derive(Debug)]
+/// enum ExampleEnum {
+///   Foo { field: i32 },
+///   Bar { other_field: String },
+/// }
+///
+/// let value = ExampleEnum::Foo { field: 42 };
+/// must_let!(ExampleEnum::Bar { other_field } = value); // panics
+/// ```
+///
+/// With `must_let!` it is possible to access multiple values.
+///
+/// ```
+/// use unsafe_get::must_let;
+///
+/// #[derive(Debug)]
+/// enum ExampleEnum {
+///     Foo { foo: i32 },
+///     Bar { bar: bool },
+///     Baz { a: i32, b: i32 },
+/// }
+///
+/// let value = ExampleEnum::Baz { a: 3, b: 4 };
+/// must_let!(ExampleEnum::Baz { a, b } = value);
+/// assert_eq!((a, b), (3, 4));
+/// ```
+///
+/// There are some limitations to the patterns that may be used with the current
+/// implementation of `must_let!`:
+///
+/// - If you use `field : variable_name` syntax to bind a value to a custom
+///   variable name, you must do so for all the bindings in the pattern. For
+///   example, `must_let!(ExampleEnum::Baz { a: x, b } = value)` will not work,
+///   but `must_let!(ExampleEnum::Baz { a: x, b: y } = value)` will work.
+///
+/// - Nested patterns are not supported. For example,
+///   `must_let!(Some(ExampleEnum::Foo { foo }) = value)` will not work.
+#[macro_export]
+macro_rules! must_let {
+    (@as_binding ..) => { _ };
+    (@as_binding $field:pat) => { $field };
+
+    (@as_value ..) => { () };
+    (@as_value $field:ident) => { $field };
+
+    ($constructor:path { $($field:ident: $binding:ident),+ } = $value:expr) => {
+        let ($(must_let!(@as_binding $binding)),+) = match $value {
+            $constructor { $($field: $binding),+ } => ($(must_let!(@as_value $binding)),+),
+            _ => panic!(
+                "must_let!: expected enum constructor: {}, got {:?}",
+                stringify!($constructor),
+                $value
+            ),
+        };
+    };
+
+    ($constructor:path { $($binding:tt),+ } = $value:expr) => {
+        let ($(must_let!(@as_binding $binding)),+) = match $value {
+            $constructor { $($binding),+ } => ($(must_let!(@as_value $binding)),+),
+            _ => panic!(
+                "must_let!: expected enum constructor: {}, got {:?}",
+                stringify!($constructor),
+                $value
+            ),
+        };
+    };
+
+    ($($constructor:ident)::+ ( $($binding:tt),+ ) = $value:expr) => {
+        let ($(must_let!(@as_binding $binding)),+) = match $value {
+            $($constructor)::+ ( $($binding),+ ) => ($(must_let!(@as_value $binding)),+),
+            _ => panic!(
+                "must_let!: expected enum constructor: {}, got {:?}",
+                stringify!($($constructor)::+),
+                $value
+            ),
+        };
+    };
+}

--- a/tests/must_let.rs
+++ b/tests/must_let.rs
@@ -1,0 +1,79 @@
+#![allow(clippy::blacklisted_name)]
+
+use unsafe_get::must_let;
+
+#[derive(Debug)]
+enum Enum {
+    Foo { foo: i32 },
+    Bar { bar: bool },
+    Baz { a: i32, b: i32 },
+}
+
+#[test]
+fn returns_enum_fields() {
+    let value = Enum::Foo { foo: 42 };
+    must_let!(Enum::Foo { foo } = value);
+    assert_eq!(foo, 42);
+}
+
+#[test]
+#[should_panic(expected = "must_let!: expected enum constructor: Enum::Foo, got Bar { bar: true }")]
+fn panics_in_case_of_getting_passed_in_the_wrong_enum_constructor() {
+    let value = Enum::Bar { bar: true };
+    must_let!(Enum::Foo { foo } = value);
+    assert_ne!(foo, 1); // use `foo` to suppress unused variable warning
+}
+
+#[test]
+fn works_for_different_types() {
+    let value = Enum::Bar { bar: true };
+    must_let!(Enum::Bar { bar } = value);
+    assert_eq!(bar, true);
+}
+
+#[test]
+fn binds_multiple_variables() {
+    let value = Enum::Baz { a: 3, b: 4 };
+    must_let!(Enum::Baz { a, b } = value);
+    assert_eq!((a, b), (3, 4));
+}
+
+#[test]
+fn accepts_pattern_with_spread() {
+    let value = Enum::Baz { a: 3, b: 4 };
+    must_let!(Enum::Baz { a, .. } = value);
+    assert_eq!(a, 3);
+}
+
+#[test]
+fn matches_tuple_constructor() {
+    let value = Some(42);
+    must_let!(Some(x) = value);
+    assert_eq!(x, 42);
+}
+
+#[test]
+fn matches_tuple_constructor_with_path() {
+    let value = Some(42);
+    must_let!(std::option::Option::Some(x) = value);
+    assert_eq!(x, 42);
+}
+
+#[test]
+fn binds_field_value_to_arbitrary_variable_name() {
+    let value = Enum::Foo { foo: 42 };
+    must_let!(Enum::Foo { foo: x } = value);
+    assert_eq!(x, 42);
+}
+
+#[test]
+fn binds_multiple_field_values_to_custom_variables() {
+    let value = Enum::Baz { a: 3, b: 4 };
+    must_let!(
+        Enum::Baz {
+            a: value_a,
+            b: value_b
+        } = value
+    );
+    assert_eq!((value_a, value_b), (3, 4));
+}


### PR DESCRIPTION
I wanted to use unsafe_get as a case study to learn more about Rust macros. I implemented a new macro, `must_let!`, which binds variables based on patterns instead of producing a value.

The advantages are that it is easier (for me at least) to read `must_let!` compared to `get!` due to the resemblance to native Rust syntax, and `must_let!` can be used to access multiple values.

There are some irritating limitations in the implementation here which are noted in the documentation with `must_let!`.  It might be possible to overcome these with more knowledge of macros than I currently posses, or by using procedural macros.

While working on this I found a crate with similar functionality, [enum_extract](https://github.com/mystor/enum_extract), which provides a similar pattern syntax to `must_let!`. A key difference is that enum_extract requires the user to specify code for the `match` branch that does not match the given pattern.